### PR TITLE
Automatic Restart of Liquidsoap if ffmpeg crashes on connect

### DIFF
--- a/liquidsoap.liq
+++ b/liquidsoap.liq
@@ -312,17 +312,18 @@ let azuracast_public.apiKey = azuracast_public_api_key
 # Extract station ID from internal API url above: `/internal/{number}/`
 def azuracast_public.stationId() = 
   let matcher = regexp("/internal/(\\d+)/")
-  list.hd(matcher.exec(azuracast_api_url), default=0)
+  # returns [(index, value)]
+  snd(list.hd(matcher.exec(azuracast_api_url), default=(0, "0")))
 end
   
-def azuracast_public.call(endpoint, payload) =
-  let api_url = "#{azuracast_public.apiBase}/api/station/#{azuracast_public.stationId}/#{endpoint}"
+def azuracast_public.call(endpoint, payload={}) =
+  let api_url = "#{!azuracast_public.apiBase}/api/station/#{azuracast_public.stationId()}/#{endpoint}"
   log("Azuracast Public: #{api_url}")
 
   ignore(curl.json(
     data=payload,
     headers=[
-      ("X-Api-Key", azuracast_public.apiKey)
+      ("X-Api-Key", !azuracast_public.apiKey)
     ],
     api_url))
 end
@@ -957,15 +958,15 @@ def ingest.makeCreekStreamerSource(
     # restart the server.
 
     # Clear the count afer successRestartWindow seconds (e.g. 10.)
-    if (successCount == 0) then
+    if (!successCount == 0) then
       thread.run(fast=false, delay=successRestartWindow, reset_success_count)
     end
 
-    successCount := successCount + 1
+    successCount := !successCount + 1
 
     # If this is the nth successful connection within the window, presume crashing is occuring,
     # and restart the server.
-    if (successCount > successRestartThreshold) then
+    if (!successCount > successRestartThreshold) then
       slack.log(":boom: #{dj} was booted from #{studioName} #{successRestartThreshold} times in #{successRestartWindow} seconds.")
       slack.log(":boom: Ingest server is likely crashing. Automatic recovery triggered: Restarting Azurcast...")
       log.info("#{studioName} ingest crashed! Automatic recovery triggering Azuracast restart...")

--- a/liquidsoap.liq
+++ b/liquidsoap.liq
@@ -848,6 +848,15 @@ def ingest.makeCreekStreamerSource(
     ingest.registerSource(studioName, highPriority)
   end
 
+  # Count successful connections within 10s period to catch ffmpeg crashes
+  let successCount = ref(0)
+  let successRestartThreshold = 10
+  let successRestartWindow = 10.
+
+  def reset_success_count() =
+    successCount := 0
+  end
+
   # Keep track of who the last DJ was so we can monitor when it changes.
   lastDj = ref("")
 
@@ -902,6 +911,32 @@ def ingest.makeCreekStreamerSource(
       end
       connectionsDebug = list.fold(listToString, "", !ingest.connections)
       log.debug("Connections After Add: #{connectionsDebug}")
+    end
+
+    # HACK: Count successful connections in a short time window. If a DJ
+    # repeatedly, successfully reconnects within a short span, it's an indicator
+    # that the ingest server is crashing at the ffmpeg level. To remedy this, we
+    # restart the server.
+
+    # Clear the count afer successRestartWindow seconds (e.g. 10.)
+    if (successCount == 0) then
+      thread.run(fast=false, delay=successRestartWindow, reset_success_count)
+    end
+
+    successCount := successCount + 1
+
+    # If this is the nth successful connection within the window, presume crashing is occuring,
+    # and restart the server.
+    if (successCount > successRestartThreshold) then
+      slack.log(":boom: #{dj} was booted from #{studioName} #{successRestartThreshold} times in #{successRestartWindow} seconds.")
+      slack.log(":boom: Ingest server is likely crashing. Automatic recovery triggered: Restarting Azurcast...")
+      log.info("#{studioName} ingest crashed! Automatic recovery triggering Azuracast restart...")
+
+      _ = azuracast_api_call(
+        timeout_ms=10000,
+        "restart",
+        ""
+      )
     end
 
     log.info("#{studioName} connected! DJ: #{dj} - #{header}")

--- a/liquidsoap.liq
+++ b/liquidsoap.liq
@@ -116,7 +116,7 @@ ignore(to_live)
 azuracast_api_url = "http://127.0.0.1:6010/api/internal/1/liquidsoap"
 azuracast_api_key = "(PASSWORD)"
 
-def azuracast_api_call(~timeout_ms=2000, url, payload) =
+def azuracast_api_call(~timeout_ms=2000, url, payload="") =
     full_url = "#{azuracast_api_url}/#{url}"
 
     log("API #{url} - Sending POST request to '#{full_url}' with body: #{payload}")
@@ -216,6 +216,10 @@ let curl = ()
 let curl.version = ref(list.hd(default="curl/unknown", process.read.lines("curl --version | head -1 | awk '{ print $1 \"/\" $2 }'")))
 let curl.userAgent = ref("Liquidsoap/#{liquidsoap.version} (#{!curl.version}) #{!user_agent_name} <#{!user_agent_url}>")
 
+def curl.headers(headers=[]) =
+  list.add(("User-Agent", !curl.userAgent), headers)
+end
+
 # Provide a data object ala
 #
 # {
@@ -223,14 +227,14 @@ let curl.userAgent = ref("Liquidsoap/#{liquidsoap.version} (#{!curl.version}) #{
 #   another: "more"
 # }
 #
-def curl.json(~data={}, ~timeout_ms=2000, theUrl) =
+def curl.json(~data={}, ~timeout_ms=2000, ~headers=[], theUrl) =
   log("cURL JSON: #{theUrl}")
   try
     response = http.post(theUrl,
-      headers=[
-        ("User-Agent", !curl.userAgent),
-        ("Content-Type", "application/json")
-      ],
+      headers=curl.headers(list.add(
+        ("Content-Type", "application/json"),
+        headers
+      )),
       timeout_ms=timeout_ms,
       data=json.stringify(compact=true, data)
     )
@@ -260,10 +264,10 @@ def curl.post(~data=[], ~timeout_ms=2000, theUrl) =
 
   try
     response = http.post(theUrl,
-      headers=[
-        ("User-Agent", !curl.userAgent),
-        ("Content-Type", "application/x-www-form-urlencoded")
-      ],
+      headers=curl.headers(list.add(
+        ("Content-Type", "application/x-www-form-urlencoded"),
+        headers
+      )),
       timeout_ms=timeout_ms,
       data=formData
     )
@@ -279,6 +283,7 @@ def curl.fetch(~timeout_ms=2000, theUrl) =
   log("cURL GET: #{theUrl}")
   try
     response = http.get(theUrl,
+      headers=curl.headers(headers),
       headers=[("User-Agent", !curl.userAgent)],
       timeout_ms=timeout_ms
     )
@@ -287,6 +292,32 @@ def curl.fetch(~timeout_ms=2000, theUrl) =
     log("cURL GET: #{theUrl} - Error: #{error.kind(err)} - #{error.message(err)}")
     "Unknown HTTP error"
   end
+end
+
+## AzurazCast Public API Functions
+# Functionality that calls the public API for AzuraCast, rather than the internal
+# azuracast_api_call version.
+let azurcast_public = ()
+let azuracast_public.apiBase = azuracast_public_url
+let azuracast_public.apiKey = azuracast_public_api_key
+  
+# Extract station ID from internal API url above: `/internal/{number}/`
+def azuracast_public.stationId() = 
+  let matcher = regexp("/internal/(\d+)/")
+  list.hd(matcher.exex(azuracast_api_url), default=0)
+end
+  
+def azuracast_public.call(endpoint, payload) =
+  let api_url = "#{azuracast_public.apiBase}/api/station/#{azuracast_public.stationId}/#{endpoint}"
+  log("Azuracast Public: #{api_url}")
+
+  # Need to add X-API-Key header.
+  ignore(curl.json(
+    data=payload,
+    headers=[
+      ("X-Api-Key", azuracast_public.apiKey)
+    ],
+    api_url))
 end
 
 ## BFF.fm API functions

--- a/liquidsoap.liq
+++ b/liquidsoap.liq
@@ -17,6 +17,10 @@ user_agent_url = ref("https://bff.fm")
 mp3_technical_difficulties = ref("https://.../broadcast-server-test-feed.mp3")
 mp3_test_feed = ref("https://.../broadcast-server-test-feed.mp3")
 
+## Azuracast Public API info
+azuracast_public_url = ref("https://broadcast.example.com")
+azuracast_public_api_key = ref("(PASSWORD)")
+
 ## Creek CMS integration
 # BFF.fm uses a modified version of Creek as its CMS, through which we authenticate
 # our streamers, and also pull canonical track metadata.
@@ -254,7 +258,7 @@ end
 #   ("another", "more")
 # ]
 #
-def curl.post(~data=[], ~timeout_ms=2000, theUrl) =
+def curl.post(~data=[], ~timeout_ms=2000, ~headers=[], theUrl) =
   log("cURL POST: #{theUrl}")
 
   def buildDataString(data, arg) =
@@ -279,12 +283,14 @@ def curl.post(~data=[], ~timeout_ms=2000, theUrl) =
   end
 end
 
-def curl.fetch(~timeout_ms=2000, theUrl) =
+def curl.fetch(~timeout_ms=2000, ~headers=[], theUrl) =
   log("cURL GET: #{theUrl}")
   try
     response = http.get(theUrl,
-      headers=curl.headers(headers),
-      headers=[("User-Agent", !curl.userAgent)],
+      headers=curl.headers(list.add(
+        ("Content-Type", "application/x-www-form-urlencoded"),
+        headers
+      )),
       timeout_ms=timeout_ms
     )
     "#{response}"
@@ -294,24 +300,25 @@ def curl.fetch(~timeout_ms=2000, theUrl) =
   end
 end
 
-## AzurazCast Public API Functions
+## Azuracast Public API Functions
 # Functionality that calls the public API for AzuraCast, rather than the internal
 # azuracast_api_call version.
-let azurcast_public = ()
+#
+# You need to provide an API key with `Administer Stations` permission.
+let azuracast_public = ()
 let azuracast_public.apiBase = azuracast_public_url
 let azuracast_public.apiKey = azuracast_public_api_key
   
 # Extract station ID from internal API url above: `/internal/{number}/`
 def azuracast_public.stationId() = 
-  let matcher = regexp("/internal/(\d+)/")
-  list.hd(matcher.exex(azuracast_api_url), default=0)
+  let matcher = regexp("/internal/(\\d+)/")
+  list.hd(matcher.exec(azuracast_api_url), default=0)
 end
   
 def azuracast_public.call(endpoint, payload) =
   let api_url = "#{azuracast_public.apiBase}/api/station/#{azuracast_public.stationId}/#{endpoint}"
   log("Azuracast Public: #{api_url}")
 
-  # Need to add X-API-Key header.
   ignore(curl.json(
     data=payload,
     headers=[
@@ -465,7 +472,7 @@ def tunein.nonMusic(~attribution, ~name) =
   tunein.airRequest([
     ("artist", attribution),
     ("title", name),
-#    ("commercial", "true")
+    # ("commercial", "true")
   ])
 end
 
@@ -963,11 +970,7 @@ def ingest.makeCreekStreamerSource(
       slack.log(":boom: Ingest server is likely crashing. Automatic recovery triggered: Restarting Azurcast...")
       log.info("#{studioName} ingest crashed! Automatic recovery triggering Azuracast restart...")
 
-      _ = azuracast_api_call(
-        timeout_ms=10000,
-        "restart",
-        ""
-      )
+      azuracast_public.call("backend/restart")
     end
 
     log.info("#{studioName} connected! DJ: #{dj} - #{header}")


### PR DESCRIPTION
We have an occasional issue where DJs connecting to a Liquidsoap harbor will be immediately disconnected. We see in Liquidsoap logs that there’s a low-level crash in ffmpeg when this happens.

Restarting Liquidsoap resolves the issue, so this patch automates that: Counting connection attempts within a 10s window, and calling restart on the Azuracast API when a threshold is exceeded.

Adds:

1. Functions for calling the Public Azuracast API
2. Enhancement of the curl/http wrappers to help with that.
3. Connection attempt threshold counting and Slack logging.